### PR TITLE
Update incorrect timestamp units on one of the tests of bank system

### DIFF
--- a/Questions/bank_system/test_bank_system.py
+++ b/Questions/bank_system/test_bank_system.py
@@ -1,7 +1,7 @@
 """
 Testing suite for the Bank System simulation.
 ============================================================
-This suite uses pytest to validate the functionality of the bank system 
+This suite uses pytest to validate the functionality of the bank system
 simulation.
 
 Author: Eric Zheng
@@ -10,9 +10,9 @@ Date: Jan 2026
 import pytest
 import sys
 import os
-from simulation import Simulation 
+from simulation import Simulation
 
-class TestLevel1:  
+class TestLevel1:
     def test_create_account(self):
         simulation = Simulation()
         assert simulation.create_account(1, "acc1") == True
@@ -33,7 +33,7 @@ class TestLevel1:
         assert simulation.deposit(3, "acc1", 1000) == 1000
         assert simulation.transfer(4, "acc1", "acc2", 300) == 700
         # Insufficient funds
-        assert simulation.transfer(5, "acc1", "acc2", 800) == None 
+        assert simulation.transfer(5, "acc1", "acc2", 800) == None
         # Non-existent account
         assert simulation.transfer(6, "acc1", "non_existent", 100) == None
         # Transfer to self
@@ -48,7 +48,7 @@ class TestLevel1:
         assert simulation.deposit(5, "account1", 2700) == 2700
         assert simulation.transfer(6, "account1", "account2", 2701) == None
         assert simulation.transfer(7, "account1", "account2", 200) == 2500
-    
+
     def test_2(self):
         simulation = Simulation()
         assert simulation.create_account(1, "A") == True
@@ -76,7 +76,7 @@ class TestLevel2:
         assert top_0 == []
         top_5 = simulation.top_spenders(2, 5)
         assert top_5 == []
-    
+
     def test_top_spenders_single_account_less_than_n(self):
         simulation = Simulation()
         simulation.create_account(1, "acc1")
@@ -144,7 +144,7 @@ class TestLevel3:
         # Create a different account
         simulation.create_account(4, "acc2")
         # Querying payment status with wrong account_id
-        assert simulation.get_payment_status(4, "acc2", payment_id) == None 
+        assert simulation.get_payment_status(4, "acc2", payment_id) == None
 
     def test_pay_cashback_and_status(self):
         simulation = Simulation()
@@ -153,19 +153,21 @@ class TestLevel3:
         payment_id = simulation.pay(3, "acc1", 500)
         assert payment_id == "payment1"
         # Before cashback time
-        status_in_progress = simulation.get_payment_status(4, "acc1", 
+        status_in_progress = simulation.get_payment_status(4, "acc1",
                                                            payment_id)
         assert status_in_progress == "IN_PROGRESS"
-        status_before_cashback = simulation.get_payment_status(26*3600, 
-                                                               "acc1", 
+        status_before_cashback = simulation.get_payment_status(26*3600,
+                                                               "acc1",
                                                                payment_id)
         # After cashback time (Exactly 24 hours after the payment)
-        status_after_cashback = simulation.get_payment_status(24 * 60 * 60 * 1000 + 3, 
-                                                              "acc1", 
+        status_after_cashback = simulation.get_payment_status(24 * 60 * 60 * 1000 + 3,
+                                                              "acc1",
                                                               payment_id)
         assert status_after_cashback == "CASHBACK_RECEIVED"
         # Check balance after cashback
-        final_balance = simulation.deposit(28*3600, "acc1", 0)  # deposit 0 to get current balance
+        final_balance = simulation.deposit(28 * 60 * 60 * 1000,
+                                            "acc1",
+                                            0)  # deposit 0 to get current balance
         assert final_balance == 1000 - 500 + 10  # 2% of 500 is 10
 
 class TestLevel4:
@@ -183,13 +185,13 @@ class TestLevel4:
         simulation = Simulation()
         simulation.create_account(1, "acc1")
         simulation.deposit(2, "acc1", 1000)
-        payment_id = simulation.pay(3, "acc1", 500) 
+        payment_id = simulation.pay(3, "acc1", 500)
         assert payment_id is not None
         simulation.create_account(4, "acc2")
         simulation.merge_accounts(5, "acc2", "acc1")
         status_acc2 = simulation.get_payment_status(6, "acc2", payment_id)
         assert status_acc2 == "IN_PROGRESS"
-        status_after_cashback = simulation.get_payment_status(24 * 60 * 60 * 1000 + 3, 
+        status_after_cashback = simulation.get_payment_status(24 * 60 * 60 * 1000 + 3,
                                                               "acc2",
                                                                 payment_id)
         assert status_after_cashback == "CASHBACK_RECEIVED"
@@ -199,10 +201,10 @@ class TestLevel4:
         simulation = Simulation()
         simulation.create_account(1, "acc1")
         simulation.deposit(2, "acc1", 1000)
-        simulation.pay(3, "acc1", 500) 
+        simulation.pay(3, "acc1", 500)
         simulation.create_account(4, "acc2")
         simulation.deposit(5, "acc2", 2000)
-        simulation.pay(6, "acc2", 800) 
+        simulation.pay(6, "acc2", 800)
         simulation.merge_accounts(7, "acc1", "acc2")
         top_1 = simulation.top_spenders(8, 1)
         assert top_1 == ["acc1(1300)"]  # acc1 now has acc2's outgoing too
@@ -213,12 +215,9 @@ class TestLevel4:
         simulation.deposit(2, "acc1", 1000)
         simulation.pay(3, "acc1", 300)
         assert simulation.get_balance(4, "acc1", 3) == 700
-        assert simulation.get_balance(24 * 60 * 60 * 1000 + 5, 
-                                      "acc1", 
+        assert simulation.get_balance(24 * 60 * 60 * 1000 + 5,
+                                      "acc1",
                                       24 * 60 * 60 * 1000 + 2) == 700
-        assert simulation.get_balance(24 * 60 * 60 * 1000 + 5, 
-                                      "acc1", 
+        assert simulation.get_balance(24 * 60 * 60 * 1000 + 5,
+                                      "acc1",
                                       24 * 60 * 60 * 1000 + 3) == 706
-
-
-


### PR DESCRIPTION
`test_bank_system.py::TestLevel2::test_pay_cashback_and_status` was failing for me because the final balance check in line 168 was in seconds instead of milliseconds.

Previous:
```python
final_balance = simulation.deposit(28 * 3600,
                                            "acc1",
                                            0)  # deposit 0 to get current balance
        assert final_balance == 1000 - 500 + 10  # 2% of 500 is 10
```

Updated to consistent units for timestamps:
```python
final_balance = simulation.deposit(28 * 60 * 60 * 1000,
                                            "acc1",
                                            0)  # deposit 0 to get current balance
        assert final_balance == 1000 - 500 + 10  # 2% of 500 is 10
```